### PR TITLE
Support ES bundlers

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.1",
   "description": "Tiny, simple, and robust technique for defining and acting with local states",
   "main": "dist/state-local.js",
-  "module": "src/index.js",
+  "module": "dist/state-local.js",
   "types": "dist/types.d.ts",
   "author": "Suren Atoyan <contact@surenatoyan.com>",
   "license": "MIT",


### PR DESCRIPTION
ES-aware tools like Rollup or Snowpack use `package.json` `module` instead of the `main`.

Therefore, your `main` must exist in the published npm package. As a stop-gap solution, so they don't break, I've just set it to your module from dist.